### PR TITLE
Update yuzu to 1559

### DIFF
--- a/abi_used_symbols
+++ b/abi_used_symbols
@@ -840,6 +840,7 @@ libQt5Widgets.so.5:_ZN12QProgressBar8setValueEi
 libQt5Widgets.so.5:_ZN12QProgressBar9setFormatERK7QString
 libQt5Widgets.so.5:_ZN12QProgressBarC1EP7QWidget
 libQt5Widgets.so.5:_ZN12QRadioButtonC1EP7QWidget
+libQt5Widgets.so.5:_ZN12QRadioButtonC1ERK7QStringP7QWidget
 libQt5Widgets.so.5:_ZN12QStyleOption4initEPK7QWidget
 libQt5Widgets.so.5:_ZN12QStyleOptionC1Eii
 libQt5Widgets.so.5:_ZN12QStyleOptionD1Ev
@@ -878,11 +879,14 @@ libQt5Widgets.so.5:_ZN15QAbstractSlider12valueChangedEi
 libQt5Widgets.so.5:_ZN15QAbstractSlider14setOrientationEN2Qt11OrientationE
 libQt5Widgets.so.5:_ZN15QAbstractSlider15actionTriggeredEi
 libQt5Widgets.so.5:_ZN15QAbstractSlider16staticMetaObjectE
+libQt5Widgets.so.5:_ZN15QAbstractSlider19setInvertedControlsEb
 libQt5Widgets.so.5:_ZN15QAbstractSlider21setInvertedAppearanceEb
 libQt5Widgets.so.5:_ZN15QAbstractSlider8setValueEi
 libQt5Widgets.so.5:_ZN15QListWidgetItem7setDataEiRK8QVariant
 libQt5Widgets.so.5:_ZN15QListWidgetItem8setFlagsE6QFlagsIN2Qt8ItemFlagEE
 libQt5Widgets.so.5:_ZN15QListWidgetItemC1ERK7QStringP11QListWidgeti
+libQt5Widgets.so.5:_ZN15QProgressDialog12setAutoCloseEb
+libQt5Widgets.so.5:_ZN15QProgressDialog12setAutoResetEb
 libQt5Widgets.so.5:_ZN15QProgressDialog12setLabelTextERK7QString
 libQt5Widgets.so.5:_ZN15QProgressDialog18setMinimumDurationEi
 libQt5Widgets.so.5:_ZN15QProgressDialog8setRangeEii
@@ -1154,10 +1158,12 @@ libQt5Widgets.so.5:_ZN9QCheckBoxC1EP7QWidget
 libQt5Widgets.so.5:_ZN9QCheckBoxC1ERK7QStringP7QWidget
 libQt5Widgets.so.5:_ZN9QComboBox10insertItemEiRK5QIconRK7QStringRK8QVariant
 libQt5Widgets.so.5:_ZN9QComboBox10removeItemEi
+libQt5Widgets.so.5:_ZN9QComboBox11setEditableEb
 libQt5Widgets.so.5:_ZN9QComboBox11setItemTextEiRK7QString
 libQt5Widgets.so.5:_ZN9QComboBox14setCurrentTextERK7QString
 libQt5Widgets.so.5:_ZN9QComboBox15setCurrentIndexEi
 libQt5Widgets.so.5:_ZN9QComboBox16staticMetaObjectE
+libQt5Widgets.so.5:_ZN9QComboBox18currentTextChangedERK7QString
 libQt5Widgets.so.5:_ZN9QComboBox19currentIndexChangedEi
 libQt5Widgets.so.5:_ZN9QComboBox24setMinimumContentsLengthEi
 libQt5Widgets.so.5:_ZN9QComboBox5clearEv
@@ -1343,6 +1349,7 @@ libQt5Widgets.so.5:_ZThn16_NK7QWidget13sharedPainterEv
 libQt5Widgets.so.5:_ZThn16_NK7QWidget6metricEN12QPaintDevice17PaintDeviceMetricE
 libQt5Widgets.so.5:_ZThn16_NK7QWidget7devTypeEv
 libSDL2-2.0.so.0:SDL_AddEventWatch
+libSDL2-2.0.so.0:SDL_ClearQueuedAudio
 libSDL2-2.0.so.0:SDL_CloseAudioDevice
 libSDL2-2.0.so.0:SDL_CreateWindow
 libSDL2-2.0.so.0:SDL_DelEventWatch
@@ -1626,7 +1633,6 @@ libcrypto.so.3:ASN1_STRING_get0_data
 libcrypto.so.3:ASN1_STRING_length
 libcrypto.so.3:BIO_clear_flags
 libcrypto.so.3:BIO_ctrl
-libcrypto.so.3:BIO_free
 libcrypto.so.3:BIO_free_all
 libcrypto.so.3:BIO_get_data
 libcrypto.so.3:BIO_get_new_index

--- a/package.yml
+++ b/package.yml
@@ -1,8 +1,8 @@
 name       : yuzu
-version    : 1514
-release    : 24
+version    : '1559'
+release    : 25
 source     :
-    - git|https://github.com/yuzu-emu/yuzu-mainline : mainline-0-1514
+    - git|https://github.com/yuzu-emu/yuzu-mainline : mainline-0-1559
 license    : GPL-3.0-or-later
 component  : games.emulator
 summary    : The world's most popular, open-source, Nintendo Switch emulator.

--- a/pspec_x86_64.xml
+++ b/pspec_x86_64.xml
@@ -2,8 +2,8 @@
     <Source>
         <Name>yuzu</Name>
         <Packager>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>Marcus Mellor</Name>
+            <Email>infinitymdm@gmail.com</Email>
         </Packager>
         <License>GPL-3.0-or-later</License>
         <PartOf>games.emulator</PartOf>
@@ -29,12 +29,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="24">
-            <Date>2023-08-22</Date>
-            <Version>1514</Version>
+        <Update release="25">
+            <Date>2023-09-15</Date>
+            <Version>1559</Version>
             <Comment>Packaging update</Comment>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>Marcus Mellor</Name>
+            <Email>infinitymdm@gmail.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
### Summary

Update yuzu to release 1559

Full changelog available [here](https://github.com/yuzu-emu/yuzu-mainline/compare/mainline-0-1514...mainline-0-1559).

### Test Plan

Launch yuzu, then run a game. Make sure things look mostly ok. Check that controller inputs work as expected.

### Checklist

- [x] Package was built and tested against unstable
